### PR TITLE
Genesis Adventurer V3 render contract upgrades and Bag GLR stats

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
         "prepare:arbitrum-rinkeby": "yarn workspaces run prepare:arbitrum-rinkeby"
     },
     "devDependencies": {
-        "@graphprotocol/graph-cli": "^0.23.0",
-        "@graphprotocol/graph-ts": "^0.23.1",
+        "@graphprotocol/graph-cli": "0.26.0",
+        "@graphprotocol/graph-ts": "0.26.0",
         "mustache": "^4.2.0"
     }
 }

--- a/subgraphs/ecosystem/layer1/abis/GenesisAdventurer.json
+++ b/subgraphs/ecosystem/layer1/abis/GenesisAdventurer.json
@@ -1,796 +1,1124 @@
 [
-    {
-        "anonymous": false,
-        "inputs": [
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "owner",
-                "type": "address"
-            },
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "approved",
-                "type": "address"
-            },
-            {
-                "indexed": true,
-                "internalType": "uint256",
-                "name": "tokenId",
-                "type": "uint256"
-            }
-        ],
-        "name": "Approval",
-        "type": "event"
-    },
-    {
-        "anonymous": false,
-        "inputs": [
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "owner",
-                "type": "address"
-            },
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "operator",
-                "type": "address"
-            },
-            {
-                "indexed": false,
-                "internalType": "bool",
-                "name": "approved",
-                "type": "bool"
-            }
-        ],
-        "name": "ApprovalForAll",
-        "type": "event"
-    },
-    {
-        "anonymous": false,
-        "inputs": [
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "previousOwner",
-                "type": "address"
-            },
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "newOwner",
-                "type": "address"
-            }
-        ],
-        "name": "OwnershipTransferred",
-        "type": "event"
-    },
-    {
-        "anonymous": false,
-        "inputs": [
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "from",
-                "type": "address"
-            },
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "to",
-                "type": "address"
-            },
-            {
-                "indexed": true,
-                "internalType": "uint256",
-                "name": "tokenId",
-                "type": "uint256"
-            }
-        ],
-        "name": "Transfer",
-        "type": "event"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "to",
-                "type": "address"
-            },
-            {
-                "internalType": "uint256",
-                "name": "tokenId",
-                "type": "uint256"
-            }
-        ],
-        "name": "approve",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "owner",
-                "type": "address"
-            }
-        ],
-        "name": "balanceOf",
-        "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "uint256",
-                "name": "tokenId",
-                "type": "uint256"
-            }
-        ],
-        "name": "getApproved",
-        "outputs": [
-            {
-                "internalType": "address",
-                "name": "",
-                "type": "address"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "uint256",
-                "name": "tokenId",
-                "type": "uint256"
-            }
-        ],
-        "name": "getChest",
-        "outputs": [
-            {
-                "internalType": "string",
-                "name": "",
-                "type": "string"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "uint256",
-                "name": "tokenId",
-                "type": "uint256"
-            }
-        ],
-        "name": "getFoot",
-        "outputs": [
-            {
-                "internalType": "string",
-                "name": "",
-                "type": "string"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "uint256",
-                "name": "tokenId",
-                "type": "uint256"
-            }
-        ],
-        "name": "getHand",
-        "outputs": [
-            {
-                "internalType": "string",
-                "name": "",
-                "type": "string"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "uint256",
-                "name": "tokenId",
-                "type": "uint256"
-            }
-        ],
-        "name": "getHead",
-        "outputs": [
-            {
-                "internalType": "string",
-                "name": "",
-                "type": "string"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "uint256",
-                "name": "tokenId",
-                "type": "uint256"
-            }
-        ],
-        "name": "getNeck",
-        "outputs": [
-            {
-                "internalType": "string",
-                "name": "",
-                "type": "string"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "uint256",
-                "name": "tokenId",
-                "type": "uint256"
-            }
-        ],
-        "name": "getOrder",
-        "outputs": [
-            {
-                "internalType": "string",
-                "name": "",
-                "type": "string"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "uint256",
-                "name": "tokenId",
-                "type": "uint256"
-            }
-        ],
-        "name": "getOrderColor",
-        "outputs": [
-            {
-                "internalType": "string",
-                "name": "",
-                "type": "string"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "uint256",
-                "name": "tokenId",
-                "type": "uint256"
-            }
-        ],
-        "name": "getOrderCount",
-        "outputs": [
-            {
-                "internalType": "string",
-                "name": "",
-                "type": "string"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "uint256",
-                "name": "tokenId",
-                "type": "uint256"
-            }
-        ],
-        "name": "getRing",
-        "outputs": [
-            {
-                "internalType": "string",
-                "name": "",
-                "type": "string"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "uint256",
-                "name": "tokenId",
-                "type": "uint256"
-            }
-        ],
-        "name": "getWaist",
-        "outputs": [
-            {
-                "internalType": "string",
-                "name": "",
-                "type": "string"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "uint256",
-                "name": "tokenId",
-                "type": "uint256"
-            }
-        ],
-        "name": "getWeapon",
-        "outputs": [
-            {
-                "internalType": "string",
-                "name": "",
-                "type": "string"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "_gmAddress",
-                "type": "address"
-            },
-            {
-                "internalType": "address",
-                "name": "_lootAddress",
-                "type": "address"
-            },
-            {
-                "internalType": "address[17]",
-                "name": "_DAOs",
-                "type": "address[17]"
-            },
-            {
-                "internalType": "uint256",
-                "name": "_initialPrice",
-                "type": "uint256"
-            }
-        ],
-        "name": "initialize",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "owner",
-                "type": "address"
-            },
-            {
-                "internalType": "address",
-                "name": "operator",
-                "type": "address"
-            }
-        ],
-        "name": "isApprovedForAll",
-        "outputs": [
-            {
-                "internalType": "bool",
-                "name": "",
-                "type": "bool"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "name": "itemUsedByGMID",
-        "outputs": [
-            {
-                "internalType": "bool",
-                "name": "",
-                "type": "bool"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [],
-        "name": "name",
-        "outputs": [
-            {
-                "internalType": "string",
-                "name": "",
-                "type": "string"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "name": "orderDAOs",
-        "outputs": [
-            {
-                "internalType": "address",
-                "name": "",
-                "type": "address"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [],
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
         "name": "owner",
-        "outputs": [
-            {
-                "internalType": "address",
-                "name": "",
-                "type": "address"
-            }
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "approved",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      }
+    ],
+    "name": "Approval",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "operator",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "approved",
+        "type": "bool"
+      }
+    ],
+    "name": "ApprovalForAll",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "string",
+        "name": "name",
+        "type": "string"
+      }
+    ],
+    "name": "NameAdventurer",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      },
+      {
+        "components": [
+          {
+            "internalType": "uint256",
+            "name": "lootTokenId",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint8",
+            "name": "inventoryId",
+            "type": "uint8"
+          }
         ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "uint256",
-                "name": "tokenId",
-                "type": "uint256"
-            }
+        "indexed": false,
+        "internalType": "struct GenesisAdventurerV2.Item[]",
+        "name": "itemsToName",
+        "type": "tuple[]"
+      }
+    ],
+    "name": "NameLostMana",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "previousOwner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnershipTransferred",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      }
+    ],
+    "name": "Transfer",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "adventureTimeAddress",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      }
+    ],
+    "name": "approve",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      }
+    ],
+    "name": "balanceOf",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "string",
+        "name": "name_",
+        "type": "string"
+      }
+    ],
+    "name": "daoName",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      }
+    ],
+    "name": "getApproved",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      }
+    ],
+    "name": "getChest",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      }
+    ],
+    "name": "getFoot",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      }
+    ],
+    "name": "getHand",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      }
+    ],
+    "name": "getHead",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      }
+    ],
+    "name": "getLootTokenIds",
+    "outputs": [
+      {
+        "internalType": "uint256[8]",
+        "name": "",
+        "type": "uint256[8]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "uint256",
+            "name": "lootTokenId",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint8",
+            "name": "inventoryId",
+            "type": "uint8"
+          }
         ],
-        "name": "ownerOf",
-        "outputs": [
-            {
-                "internalType": "address",
-                "name": "",
-                "type": "address"
-            }
+        "internalType": "struct GenesisAdventurerV2.Item",
+        "name": "lootItem",
+        "type": "tuple"
+      }
+    ],
+    "name": "getLostManaNameUsed",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      }
+    ],
+    "name": "getName",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      }
+    ],
+    "name": "getNeck",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      }
+    ],
+    "name": "getOrder",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      }
+    ],
+    "name": "getOrderColor",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      }
+    ],
+    "name": "getOrderCount",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      }
+    ],
+    "name": "getRing",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      }
+    ],
+    "name": "getWaist",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      }
+    ],
+    "name": "getWeapon",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_gmAddress",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_lootAddress",
+        "type": "address"
+      },
+      {
+        "internalType": "address[17]",
+        "name": "_DAOs",
+        "type": "address[17]"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_initialPrice",
+        "type": "uint256"
+      }
+    ],
+    "name": "initialize",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "operator",
+        "type": "address"
+      }
+    ],
+    "name": "isApprovedForAll",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "itemUsedByGMID",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "lostNamingAddress",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "name",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "nameAdventurerPrice",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      },
+      {
+        "components": [
+          {
+            "internalType": "uint256",
+            "name": "lootTokenId",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint8",
+            "name": "inventoryId",
+            "type": "uint8"
+          }
         ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [],
-        "name": "publicPrice",
-        "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [],
-        "name": "renounceOwnership",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "uint256",
-                "name": "weaponTokenId",
-                "type": "uint256"
-            },
-            {
-                "internalType": "uint256",
-                "name": "chestTokenId",
-                "type": "uint256"
-            },
-            {
-                "internalType": "uint256",
-                "name": "headTokenId",
-                "type": "uint256"
-            },
-            {
-                "internalType": "uint256",
-                "name": "waistTokenId",
-                "type": "uint256"
-            },
-            {
-                "internalType": "uint256",
-                "name": "footTokenId",
-                "type": "uint256"
-            },
-            {
-                "internalType": "uint256",
-                "name": "handTokenId",
-                "type": "uint256"
-            },
-            {
-                "internalType": "uint256",
-                "name": "neckTokenId",
-                "type": "uint256"
-            },
-            {
-                "internalType": "uint256",
-                "name": "ringTokenId",
-                "type": "uint256"
-            }
-        ],
-        "name": "resurrectGA",
-        "outputs": [],
-        "stateMutability": "payable",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "from",
-                "type": "address"
-            },
-            {
-                "internalType": "address",
-                "name": "to",
-                "type": "address"
-            },
-            {
-                "internalType": "uint256",
-                "name": "tokenId",
-                "type": "uint256"
-            }
-        ],
-        "name": "safeTransferFrom",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "from",
-                "type": "address"
-            },
-            {
-                "internalType": "address",
-                "name": "to",
-                "type": "address"
-            },
-            {
-                "internalType": "uint256",
-                "name": "tokenId",
-                "type": "uint256"
-            },
-            {
-                "internalType": "bytes",
-                "name": "_data",
-                "type": "bytes"
-            }
-        ],
-        "name": "safeTransferFrom",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "operator",
-                "type": "address"
-            },
-            {
-                "internalType": "bool",
-                "name": "approved",
-                "type": "bool"
-            }
-        ],
-        "name": "setApprovalForAll",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "uint256",
-                "name": "_newPrice",
-                "type": "uint256"
-            }
-        ],
-        "name": "setPrice",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "bytes4",
-                "name": "interfaceId",
-                "type": "bytes4"
-            }
-        ],
-        "name": "supportsInterface",
-        "outputs": [
-            {
-                "internalType": "bool",
-                "name": "",
-                "type": "bool"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [],
-        "name": "symbol",
-        "outputs": [
-            {
-                "internalType": "string",
-                "name": "",
-                "type": "string"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "uint256",
-                "name": "index",
-                "type": "uint256"
-            }
-        ],
-        "name": "tokenByIndex",
-        "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "owner",
-                "type": "address"
-            },
-            {
-                "internalType": "uint256",
-                "name": "index",
-                "type": "uint256"
-            }
-        ],
-        "name": "tokenOfOwnerByIndex",
-        "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "uint256",
-                "name": "tokenId",
-                "type": "uint256"
-            }
-        ],
-        "name": "tokenURI",
-        "outputs": [
-            {
-                "internalType": "string",
-                "name": "",
-                "type": "string"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [],
-        "name": "totalSupply",
-        "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "from",
-                "type": "address"
-            },
-            {
-                "internalType": "address",
-                "name": "to",
-                "type": "address"
-            },
-            {
-                "internalType": "uint256",
-                "name": "tokenId",
-                "type": "uint256"
-            }
-        ],
-        "name": "transferFrom",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "newOwner",
-                "type": "address"
-            }
-        ],
-        "name": "transferOwnership",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [],
-        "name": "withdraw",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    }
+        "internalType": "struct GenesisAdventurerV2.Item[]",
+        "name": "itemsToName",
+        "type": "tuple[]"
+      }
+    ],
+    "name": "nameLostMana",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "nameLostManaPrice",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "orderDAOs",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "owner",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      }
+    ],
+    "name": "ownerOf",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "publicPrice",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "rendererAddress",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "renounceOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "weaponTokenId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "chestTokenId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "headTokenId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "waistTokenId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "footTokenId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "handTokenId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "neckTokenId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "ringTokenId",
+        "type": "uint256"
+      }
+    ],
+    "name": "resurrectGA",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      }
+    ],
+    "name": "safeTransferFrom",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes",
+        "name": "_data",
+        "type": "bytes"
+      }
+    ],
+    "name": "safeTransferFrom",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "addr",
+        "type": "address"
+      }
+    ],
+    "name": "setATIME",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "operator",
+        "type": "address"
+      },
+      {
+        "internalType": "bool",
+        "name": "approved",
+        "type": "bool"
+      }
+    ],
+    "name": "setApprovalForAll",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "addr",
+        "type": "address"
+      }
+    ],
+    "name": "setLostNamingAddress",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "string",
+        "name": "name_",
+        "type": "string"
+      }
+    ],
+    "name": "setName",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "price_",
+        "type": "uint256"
+      }
+    ],
+    "name": "setNameAdventurerPrice",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "price_",
+        "type": "uint256"
+      }
+    ],
+    "name": "setNameLostManaPrice",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_newPrice",
+        "type": "uint256"
+      }
+    ],
+    "name": "setPrice",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "addr",
+        "type": "address"
+      }
+    ],
+    "name": "setRenderer",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes4",
+        "name": "interfaceId",
+        "type": "bytes4"
+      }
+    ],
+    "name": "supportsInterface",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "symbol",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "index",
+        "type": "uint256"
+      }
+    ],
+    "name": "tokenByIndex",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "index",
+        "type": "uint256"
+      }
+    ],
+    "name": "tokenOfOwnerByIndex",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      }
+    ],
+    "name": "tokenURI",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "totalSupply",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      }
+    ],
+    "name": "transferFrom",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "transferOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "withdraw",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract IERC20",
+        "name": "token",
+        "type": "address"
+      }
+    ],
+    "name": "withdrawErc20",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
 ]

--- a/subgraphs/ecosystem/layer1/schema.graphql
+++ b/subgraphs/ecosystem/layer1/schema.graphql
@@ -38,6 +38,9 @@ type Bag @entity {
   ringSuffixId: Int!
   waistSuffixId: Int!
   weaponSuffixId: Int!
+  bagGreatness: Int!
+  bagLevel: Int!
+  bagRating: Int!
   currentOwner: Wallet!
   minted: BigInt!
   manas: [Mana!]! @derivedFrom(field: "lootTokenId")
@@ -77,6 +80,9 @@ type MLoot @entity {
   ring: String!
   waist: String!
   weapon: String!
+  bagGreatness: Int!
+  bagLevel: Int!
+  bagRating: Int!
   currentOwner: Wallet!
   minted: BigInt!
 }

--- a/subgraphs/ecosystem/layer1/schema.graphql
+++ b/subgraphs/ecosystem/layer1/schema.graphql
@@ -58,6 +58,11 @@ type GAdventurer @entity {
   order: String!
   orderColor: String!
   orderCount: String!
+  bagGreatness: Int!
+  bagLevel: Int!
+  bagRating: Int!
+  lootTokenIds: [Int!]
+  tokenURI: String!
   currentOwner: Wallet!
   minted: BigInt!
 }

--- a/subgraphs/ecosystem/layer1/src/gadventurer-mapping.ts
+++ b/subgraphs/ecosystem/layer1/src/gadventurer-mapping.ts
@@ -1,47 +1,160 @@
-import { GAdventurer } from '../generated/schema';
-import { Transfer as TransferEvent } from '../generated/LootMore/LootMore';
-import { GenesisAdventurer } from '../generated/GenesisProjectAdventurer/GenesisAdventurer';
-import { getTransfer, getWallets, isZeroAddress } from './utils';
+import { GAdventurer, Transfer } from "../generated/schema";
+import {
+  NameAdventurer,
+  NameLostMana,
+  ResurrectGACall,
+  GenesisAdventurer,
+  Transfer as TransferEvent
+} from "../generated/GenesisProjectAdventurer/GenesisAdventurer";
+import { getTransfer, getWallets, isZeroAddress } from "./utils";
+import { Address, BigInt } from "@graphprotocol/graph-ts";
+import {
+  getGAdventurerGreatness,
+  getGAdventurerLevel,
+  getGAdventurerRating
+} from "./glr-utils";
 
-import { BigInt } from '@graphprotocol/graph-ts';
+const V3_CONTRACT_START_TOKEN_ID = BigInt.fromI32(480);
 
 export function handleTransfer(event: TransferEvent): void {
   let tokenId = event.params.tokenId;
-    let wallets = getWallets(event.params.from, event.params.to, event);
+  let wallets = getWallets(event.params.from, event.params.to, event);
 
-
-  if(!isZeroAddress(wallets.fromWallet.id)) {
-    wallets.fromWallet.gAdventurersHeld = wallets.fromWallet.gAdventurersHeld.minus(BigInt.fromI32(1))
+  if (!isZeroAddress(wallets.fromWallet.id)) {
+    wallets.fromWallet.gAdventurersHeld = wallets.fromWallet.gAdventurersHeld.minus(
+      BigInt.fromI32(1)
+    );
   }
-  wallets.fromWallet.save()
+  wallets.fromWallet.save();
 
-  wallets.toWallet.gAdventurersHeld = wallets.toWallet.gAdventurersHeld.plus(BigInt.fromI32(1))
-  wallets.toWallet.save()
+  wallets.toWallet.gAdventurersHeld = wallets.toWallet.gAdventurersHeld.plus(
+    BigInt.fromI32(1)
+  );
+  wallets.toWallet.save();
 
   let gAdventurer = GAdventurer.load(tokenId.toString());
+  if (gAdventurer != null) {
+    gAdventurer.currentOwner = wallets.toWallet.id;
+    gAdventurer.save();
+  } else {
+    gAdventurer = new GAdventurer(tokenId.toString());
+    let contract = GenesisAdventurer.bind(event.address);
+    // Loot Token Ids aren't availble yet on inital GA Transfer
+    // resurrectGA call handler will fill in lootIds
+    updateGAdventurerWithLootTokenIds(gAdventurer, [], contract);
+    gAdventurer.currentOwner = wallets.toWallet.id;
+    gAdventurer.minted = event.block.timestamp;
+    gAdventurer.save();
+
+    // New V3 contract updates renderer
+    if (tokenId.equals(V3_CONTRACT_START_TOKEN_ID)) {
+      refreshAdventurersBeforeTokenId(
+        V3_CONTRACT_START_TOKEN_ID,
+        event.address
+      );
+    }
+  }
+
+  let transfer = getTransfer(event, wallets);
+  transfer.gAdventurer = tokenId.toString();
+  transfer.save();
+}
+
+export function handleResurrectGA(call: ResurrectGACall): void {
+  const transfer = Transfer.load(call.transaction.hash.toHex() + "0");
+  if (transfer != null && transfer.gAdventurer != null) {
+    const gAdventurer = GAdventurer.load(transfer.gAdventurer as string);
     if (gAdventurer != null) {
-      gAdventurer.currentOwner = wallets.toWallet.id;
-      gAdventurer.save();
-    } else {
-      gAdventurer = new GAdventurer(tokenId.toString());
-      let contract = GenesisAdventurer.bind(event.address);
-      gAdventurer.chest = contract.getChest(tokenId);
-      gAdventurer.foot = contract.getFoot(tokenId);
-      gAdventurer.hand = contract.getHand(tokenId);
-      gAdventurer.head = contract.getHead(tokenId);
-      gAdventurer.neck = contract.getNeck(tokenId);
-      gAdventurer.ring = contract.getRing(tokenId);
-      gAdventurer.waist = contract.getWaist(tokenId);
-      gAdventurer.weapon = contract.getWeapon(tokenId);
-      gAdventurer.order = contract.getOrder(tokenId);
-      gAdventurer.orderColor = contract.getOrderColor(tokenId);
-      gAdventurer.orderCount = contract.getOrder(tokenId);
-      gAdventurer.currentOwner = wallets.toWallet.id;
-      gAdventurer.minted = event.block.timestamp;
+      let contract = GenesisAdventurer.bind(call.to);
+      updateGAdventurerWithLootTokenIds(
+        gAdventurer,
+        [
+          call.inputs.waistTokenId,
+          call.inputs.chestTokenId,
+          call.inputs.headTokenId,
+          call.inputs.waistTokenId,
+          call.inputs.footTokenId,
+          call.inputs.handTokenId,
+          call.inputs.neckTokenId,
+          call.inputs.ringTokenId
+        ],
+        contract
+      );
       gAdventurer.save();
     }
-  
-    let transfer = getTransfer(event, wallets)  
-    transfer.gAdventurer = tokenId.toString();
-    transfer.save();
   }
+}
+
+export function handleNameAdventurer(event: NameAdventurer): void {
+  refreshGAdventurerByTokenId(event.params.tokenId, event.address);
+}
+
+export function handleNameLostMana(event: NameLostMana): void {
+  refreshGAdventurerByTokenId(event.params.tokenId, event.address);
+}
+
+function refreshAdventurersBeforeTokenId(
+  tokenId: BigInt,
+  contractAddress: Address
+): void {
+  if (tokenId.lt(BigInt.fromI32(1))) {
+    return;
+  }
+  for (let i = tokenId.toI32() - 1; i > 0; i--) {
+    refreshGAdventurerByTokenId(BigInt.fromI32(i), contractAddress);
+  }
+}
+
+function refreshGAdventurerByTokenId(
+  tokenId: BigInt,
+  contractAddress: Address
+): void {
+  let adventurer = GAdventurer.load(tokenId.toString());
+  if (adventurer) {
+    let contract = GenesisAdventurer.bind(contractAddress);
+    updateGAdventurerWithLootTokenIds(
+      adventurer,
+      contract.getLootTokenIds(tokenId),
+      contract
+    );
+    adventurer.save();
+  }
+}
+
+export function updateGAdventurerWithLootTokenIds(
+  gAdventurer: GAdventurer,
+  lootTokenIds: BigInt[],
+  contract: GenesisAdventurer
+): void {
+  const tokenId = BigInt.fromString(gAdventurer.id);
+  gAdventurer.weapon = contract.getWeapon(tokenId);
+  gAdventurer.chest = contract.getChest(tokenId);
+  gAdventurer.head = contract.getHead(tokenId);
+  gAdventurer.waist = contract.getWaist(tokenId);
+  gAdventurer.foot = contract.getFoot(tokenId);
+  gAdventurer.hand = contract.getHand(tokenId);
+  gAdventurer.neck = contract.getNeck(tokenId);
+  gAdventurer.ring = contract.getRing(tokenId);
+  gAdventurer.order = contract.getOrder(tokenId);
+  gAdventurer.orderColor = contract.getOrderColor(tokenId);
+  gAdventurer.orderCount = contract.getOrderCount(tokenId);
+  gAdventurer.tokenURI = contract.tokenURI(tokenId);
+
+  if (lootTokenIds.length == 0) {
+    gAdventurer.lootTokenIds = [];
+    gAdventurer.bagGreatness = 0;
+    gAdventurer.bagLevel = 0;
+    gAdventurer.bagRating = 0;
+  } else {
+    gAdventurer.lootTokenIds = lootTokenIds.map(function(
+      tokenId: BigInt,
+      index: i32,
+      array: BigInt[]
+    ): i32 {
+      return tokenId.toI32();
+    });
+    gAdventurer.bagGreatness = getGAdventurerGreatness(gAdventurer);
+    gAdventurer.bagLevel = getGAdventurerLevel(gAdventurer);
+    gAdventurer.bagRating = getGAdventurerRating(gAdventurer);
+  }
+}

--- a/subgraphs/ecosystem/layer1/src/gadventurer-mapping.ts
+++ b/subgraphs/ecosystem/layer1/src/gadventurer-mapping.ts
@@ -14,7 +14,7 @@ import {
   getGAdventurerRating
 } from "./glr-utils";
 
-const V3_CONTRACT_START_TOKEN_ID = BigInt.fromI32(480);
+const V3_CONTRACT_START_TOKEN_ID = BigInt.fromI32(500);
 
 export function handleTransfer(event: TransferEvent): void {
   let tokenId = event.params.tokenId;
@@ -58,6 +58,8 @@ export function handleTransfer(event: TransferEvent): void {
   let transfer = getTransfer(event, wallets);
   transfer.gAdventurer = tokenId.toString();
   transfer.save();
+
+  
 }
 
 export function handleResurrectGA(call: ResurrectGACall): void {
@@ -97,10 +99,8 @@ function refreshAdventurersBeforeTokenId(
   tokenId: BigInt,
   contractAddress: Address
 ): void {
-  if (tokenId.lt(BigInt.fromI32(1))) {
-    return;
-  }
-  for (let i = tokenId.toI32() - 1; i > 0; i--) {
+  const start = tokenId.toI32() - 1;
+  for (let i = start; i > 0; i--) {
     refreshGAdventurerByTokenId(BigInt.fromI32(i), contractAddress);
   }
 }

--- a/subgraphs/ecosystem/layer1/src/glr-utils.ts
+++ b/subgraphs/ecosystem/layer1/src/glr-utils.ts
@@ -1,0 +1,381 @@
+import { BigInt, ByteArray, crypto } from "@graphprotocol/graph-ts";
+import { Bag, GAdventurer } from "../generated/schema";
+
+const ITEMS = [
+  // WEAPONS
+  [
+    // Warrior
+    "Warhammer",
+    "Quarterstaff",
+    "Maul",
+    "Mace",
+    "Club",
+
+    // Hunter
+    "Katana",
+    "Falchion",
+    "Scimitar",
+    "Long Sword",
+    "Short Sword",
+
+    // Mage
+    "Ghost Wand",
+    "Grave Wand",
+    "Bone Wand",
+    "Wand",
+    "",
+
+    // Mage
+    "Grimoire",
+    "Chronicle",
+    "Tome",
+    "Book"
+  ],
+
+  // CHEST
+  [
+    // Warrior
+    "Holy Chestplate",
+    "Ornate Chestplate",
+    "Plate Mail",
+    "Chain Mail",
+    "Ring Mail",
+
+    // Hunter
+    "Demon Husk",
+    "Dragonskin Armor",
+    "Studded Leather Armor",
+    "Hard Leather Armor",
+    "Leather Armor",
+
+    // Mage
+    "Divine Robe",
+    "Silk Robe",
+    "Linen Robe",
+    "Robe",
+    "Shirt"
+  ],
+
+  //HEAD
+  [
+    // Warrior
+    "Ancient Helm",
+    "Ornate Helm",
+    "Great Helm",
+    "Full Helm",
+    "Helm",
+
+    // Hunter
+    "Demon Crown",
+    "Dragon's Crown",
+    "War Cap",
+    "Leather Cap",
+    "Cap",
+
+    // Mage
+    "Crown",
+    "Divine Hood",
+    "Silk Hood",
+    "Linen Hood",
+    "Hood"
+  ],
+
+  // WAIST
+  [
+    // Warrior
+    "Ornate Belt",
+    "War Belt",
+    "Plated Belt",
+    "Mesh Belt",
+    "Heavy Belt",
+
+    // Hunter
+    "Demonhide Belt",
+    "Dragonskin Belt",
+    "Studded Leather Belt",
+    "Hard Leather Belt",
+    "Leather Belt",
+
+    // Mage
+    "Brightsilk Sash",
+    "Silk Sash",
+    "Wool Sash",
+    "Linen Sash",
+    "Sash"
+  ],
+
+  // FOOT
+  [
+    // Warrior
+    "Holy Greaves",
+    "Ornate Greaves",
+    "Greaves",
+    "Chain Boots",
+    "Heavy Boots",
+
+    // Hunter
+    "Demonhide Boots",
+    "Dragonskin Boots",
+    "Studded Leather Boots",
+    "Hard Leather Boots",
+    "Leather Boots",
+
+    // Mage
+    "Divine Slippers",
+    "Silk Slippers",
+    "Wool Shoes",
+    "Linen Shoes",
+    "Shoes"
+  ],
+
+  // HAND
+  [
+    // Warrior
+    "Holy Gauntlets",
+    "Ornate Gauntlets",
+    "Gauntlets",
+    "Chain Gloves",
+    "Heavy Gloves",
+
+    // Hunter
+    "Demon's Hands",
+    "Dragonskin Gloves",
+    "Studded Leather Gloves",
+    "Hard Leather Gloves",
+    "Leather Gloves",
+
+    // Mage
+    "Divine Gloves",
+    "Silk Gloves",
+    "Wool Gloves",
+    "Linen Gloves",
+    "Gloves"
+  ],
+
+  // NECK
+  ["Necklace", "Amulet", "Pendant"],
+
+  //RING
+  ["Gold Ring", "Silver Ring", "Bronze Ring", "Platinum Ring", "Titanium Ring"]
+];
+
+const CLASSES = ["Warrior", "Hunter", "Mage", "Mage"];
+
+const ITEMS_PREFIXES = [
+  "WEAPON",
+  "CHEST",
+  "HEAD",
+  "WAIST",
+  "FOOT",
+  "HAND",
+  "NECK",
+  "RING"
+];
+
+function getGreatnessByType(tokenId: string, keyPrefix: string): i32 {
+  const rand = random(keyPrefix + tokenId);
+  const greatness = rand.mod(BigInt.fromI32(21));
+  return greatness.toI32();
+}
+
+export function random(input: string): BigInt {
+  return BigInt.fromUnsignedBytes(
+    changetype<ByteArray>(crypto.keccak256(ByteArray.fromUTF8(input)).reverse())
+  );
+}
+
+const enum ItemType {
+  WEAPON = 0,
+  CHEST = 1,
+  HEAD = 2,
+  WAIST = 3,
+  FOOT = 4,
+  HAND = 5,
+  NECK = 6,
+  RING = 7
+}
+
+function findItemIndex(itemType: ItemType, itemName: string): i32 {
+  let items = ITEMS[itemType];
+  for (let i = 0; i < items.length; i++) {
+    const foundItem =
+      items[i] != "" &&
+      itemName.toLowerCase().indexOf(items[i].toLowerCase()) > -1;
+    if (foundItem) {
+      return i;
+    }
+  }
+  return -1;
+}
+
+export function getItemClass(itemType: ItemType, itemName: string): string {
+  if (itemType > ItemType.HAND) {
+    return "";
+  }
+
+  let itemIndex = findItemIndex(itemType, itemName);
+  if (itemIndex < 0) {
+    return "";
+  }
+  return CLASSES[Math.floor(itemIndex / 5) as i32] || "";
+}
+
+function getRingLevel(itemName: string): i32 {
+  if (itemName.toLowerCase().indexOf("bronze") > -1) {
+    return 3;
+  } else if (itemName.toLowerCase().indexOf("silver") > -1) {
+    return 2;
+  } else {
+    return 1;
+  }
+}
+
+function getItemRank(itemType: ItemType, itemName: string): i32 {
+  if (itemType === ItemType.NECK) {
+    return 1;
+  } else if (itemType === ItemType.RING) {
+    return getRingLevel(itemName);
+  }
+
+  let itemIndex = findItemIndex(itemType, itemName);
+  if (itemIndex < 0) {
+    // Default Rank. Currently Catch All for Lost Mana
+    return 5;
+  }
+  return (itemIndex % 5) + 1;
+}
+
+export function getItemLevel(
+  lootId: BigInt,
+  itemType: ItemType,
+  itemName: string
+): i32 {
+  if (lootId.equals(BigInt.fromI32(0))) {
+    return 1;
+  }
+  const rank = getItemRank(itemType, itemName);
+  if (rank === 0) {
+    // Default Power/Level 1
+    return 1;
+  }
+  if (itemType > ItemType.HAND) {
+    return 4 - rank;
+  } else {
+    return 6 - rank;
+  }
+}
+
+export function getGreatnessByItem(
+  lootTokenId: BigInt,
+  itemType: ItemType
+): i32 {
+  return getGreatnessByType(lootTokenId.toString(), ITEMS_PREFIXES[itemType]);
+}
+
+export function getBagGreatness(bag: Bag): i32 {
+  let greatness = 0;
+  for (let i = 0; i < 8; i++) {
+    greatness += getGreatnessByItem(BigInt.fromString(bag.id), i);
+  }
+  return greatness;
+}
+
+export function getGAdventurerGreatness(bag: GAdventurer): i32 {
+  let lootTokenIds = bag.lootTokenIds;
+  if (lootTokenIds == null) {
+    return 0;
+  }
+  let greatness = 0;
+  for (let i = 0; i < lootTokenIds.length; i++) {
+    // GM minimum greatness is 15
+    // Lost Mana defaults to 15
+    greatness += Math.max(
+      getGreatnessByItem(BigInt.fromI32(lootTokenIds[i]), i),
+      15
+    ) as i32;
+  }
+  return greatness;
+}
+
+export function getBagLevel(bag: Bag): i32 {
+  let level = 0;
+  const lootId = BigInt.fromString(bag.id);
+  level += getItemLevel(lootId, 0, bag.weapon);
+  level += getItemLevel(lootId, 1, bag.chest);
+  level += getItemLevel(lootId, 2, bag.head);
+  level += getItemLevel(lootId, 3, bag.waist);
+  level += getItemLevel(lootId, 4, bag.foot);
+  level += getItemLevel(lootId, 5, bag.hand);
+  level += getItemLevel(lootId, 6, bag.neck);
+  level += getItemLevel(lootId, 7, bag.ring);
+  return level;
+}
+
+export function getGAdventurerLevel(bag: GAdventurer): i32 {
+  let level = 0;
+  const lootIds = (bag.lootTokenIds as i32[]).map(function(
+    lootId: i32,
+    index: i32,
+    array: i32[]
+  ): BigInt {
+    return BigInt.fromI32(lootId);
+  });
+  level += getItemLevel(lootIds[0], 0, bag.weapon);
+  level += getItemLevel(lootIds[1], 1, bag.chest);
+  level += getItemLevel(lootIds[2], 2, bag.head);
+  level += getItemLevel(lootIds[3], 3, bag.waist);
+  level += getItemLevel(lootIds[4], 4, bag.foot);
+  level += getItemLevel(lootIds[5], 5, bag.hand);
+  level += getItemLevel(lootIds[6], 6, bag.neck);
+  level += getItemLevel(lootIds[7], 7, bag.ring);
+  return level;
+}
+
+export function getBagRating(bag: Bag): i32 {
+  const tokenId = BigInt.fromString(bag.id);
+  let rating = 0;
+  rating +=
+    getItemLevel(tokenId, 0, bag.weapon) * getGreatnessByItem(tokenId, 0);
+  rating +=
+    getItemLevel(tokenId, 1, bag.chest) * getGreatnessByItem(tokenId, 1);
+  rating += getItemLevel(tokenId, 2, bag.head) * getGreatnessByItem(tokenId, 2);
+  rating +=
+    getItemLevel(tokenId, 3, bag.waist) * getGreatnessByItem(tokenId, 3);
+  rating += getItemLevel(tokenId, 4, bag.foot) * getGreatnessByItem(tokenId, 4);
+  rating += getItemLevel(tokenId, 5, bag.hand) * getGreatnessByItem(tokenId, 5);
+  rating += getItemLevel(tokenId, 6, bag.neck) * getGreatnessByItem(tokenId, 6);
+  rating += getItemLevel(tokenId, 7, bag.ring) * getGreatnessByItem(tokenId, 7);
+  return rating;
+}
+
+export function getGAdventurerRating(bag: GAdventurer): i32 {
+  let tokenIds: BigInt[] = [];
+  if (bag.lootTokenIds != null) {
+    tokenIds = (bag.lootTokenIds as i32[]).map(function(
+      lootId: i32,
+      index: i32,
+      array: i32[]
+    ): BigInt {
+      return BigInt.fromI32(lootId);
+    });
+  }
+
+  let rating = 0;
+  rating += (getItemLevel(tokenIds[0], 0, bag.weapon) *
+    Math.max(getGreatnessByItem(tokenIds[0], 0), 15)) as i32;
+  rating += (getItemLevel(tokenIds[1], 1, bag.chest) *
+    Math.max(getGreatnessByItem(tokenIds[1], 1), 15)) as i32;
+  rating += (getItemLevel(tokenIds[2], 2, bag.head) *
+    Math.max(getGreatnessByItem(tokenIds[2], 2), 15)) as i32;
+  rating += (getItemLevel(tokenIds[3], 3, bag.waist) *
+    Math.max(getGreatnessByItem(tokenIds[3], 3), 15)) as i32;
+  rating += (getItemLevel(tokenIds[4], 4, bag.foot) *
+    Math.max(getGreatnessByItem(tokenIds[4], 4), 15)) as i32;
+  rating += (getItemLevel(tokenIds[5], 5, bag.hand) *
+    Math.max(getGreatnessByItem(tokenIds[5], 5), 15)) as i32;
+  rating += (getItemLevel(tokenIds[6], 6, bag.neck) *
+    Math.max(getGreatnessByItem(tokenIds[6], 6), 15)) as i32;
+  rating += (getItemLevel(tokenIds[7], 7, bag.ring) *
+    Math.max(getGreatnessByItem(tokenIds[7], 7), 15)) as i32;
+  return rating;
+}

--- a/subgraphs/ecosystem/layer1/src/glr-utils.ts
+++ b/subgraphs/ecosystem/layer1/src/glr-utils.ts
@@ -1,5 +1,5 @@
 import { BigInt, ByteArray, crypto } from "@graphprotocol/graph-ts";
-import { Bag, GAdventurer } from "../generated/schema";
+import { GAdventurer } from "../generated/schema";
 
 const ITEMS = [
   // WEAPONS
@@ -272,10 +272,10 @@ export function getGreatnessByItem(
   return getGreatnessByType(lootTokenId.toString(), ITEMS_PREFIXES[itemType]);
 }
 
-export function getBagGreatness(bag: Bag): i32 {
+export function getBagGreatness(tokenId: BigInt): i32 {
   let greatness = 0;
   for (let i = 0; i < 8; i++) {
-    greatness += getGreatnessByItem(BigInt.fromString(bag.id), i);
+    greatness += getGreatnessByItem(tokenId, i);
   }
   return greatness;
 }
@@ -297,17 +297,12 @@ export function getGAdventurerGreatness(bag: GAdventurer): i32 {
   return greatness;
 }
 
-export function getBagLevel(bag: Bag): i32 {
+export function getBagLevel(tokenId: BigInt, items: string[]): i32 {
   let level = 0;
-  const lootId = BigInt.fromString(bag.id);
-  level += getItemLevel(lootId, 0, bag.weapon);
-  level += getItemLevel(lootId, 1, bag.chest);
-  level += getItemLevel(lootId, 2, bag.head);
-  level += getItemLevel(lootId, 3, bag.waist);
-  level += getItemLevel(lootId, 4, bag.foot);
-  level += getItemLevel(lootId, 5, bag.hand);
-  level += getItemLevel(lootId, 6, bag.neck);
-  level += getItemLevel(lootId, 7, bag.ring);
+
+  for (let i = 0; i < 8; i++) {
+    level += getItemLevel(tokenId, i, items[i]);
+  }
   return level;
 }
 
@@ -331,20 +326,12 @@ export function getGAdventurerLevel(bag: GAdventurer): i32 {
   return level;
 }
 
-export function getBagRating(bag: Bag): i32 {
-  const tokenId = BigInt.fromString(bag.id);
+export function getBagRating(tokenId: BigInt, items: string[]): i32 {
   let rating = 0;
-  rating +=
-    getItemLevel(tokenId, 0, bag.weapon) * getGreatnessByItem(tokenId, 0);
-  rating +=
-    getItemLevel(tokenId, 1, bag.chest) * getGreatnessByItem(tokenId, 1);
-  rating += getItemLevel(tokenId, 2, bag.head) * getGreatnessByItem(tokenId, 2);
-  rating +=
-    getItemLevel(tokenId, 3, bag.waist) * getGreatnessByItem(tokenId, 3);
-  rating += getItemLevel(tokenId, 4, bag.foot) * getGreatnessByItem(tokenId, 4);
-  rating += getItemLevel(tokenId, 5, bag.hand) * getGreatnessByItem(tokenId, 5);
-  rating += getItemLevel(tokenId, 6, bag.neck) * getGreatnessByItem(tokenId, 6);
-  rating += getItemLevel(tokenId, 7, bag.ring) * getGreatnessByItem(tokenId, 7);
+  for (let i = 0; i < 8; i++) {
+    rating +=
+      getItemLevel(tokenId, i, items[i]) * getGreatnessByItem(tokenId, i);
+  }
   return rating;
 }
 

--- a/subgraphs/ecosystem/layer1/src/loot-mapping.ts
+++ b/subgraphs/ecosystem/layer1/src/loot-mapping.ts
@@ -4,6 +4,7 @@ import { getTransfer, getWallets, isZeroAddress } from './utils';
 import { Bag } from '../generated/schema';
 import { Loot } from '../generated/Loot/Loot';
 import { BigInt } from '@graphprotocol/graph-ts';
+import { getBagGreatness, getBagLevel, getBagRating } from './glr-utils';
 
 export function handleTransfer(event: TransferEvent): void {
   let tokenId = event.params.tokenId;
@@ -90,9 +91,15 @@ export function handleTransfer(event: TransferEvent): void {
     bag.currentOwner = wallets.toWallet.id;
     bag.minted = event.block.timestamp;
     bag.manasClaimed = BigInt.fromI32(0);
+    
+    const items = [bag.weapon, bag.chest, bag.head, bag.waist, bag.foot, bag.hand, bag.neck, bag.ring];
+    bag.bagGreatness = getBagGreatness(tokenId);
+    bag.bagLevel = getBagLevel(tokenId, items);
+    bag.bagRating = getBagRating(tokenId, items);
+
     bag.save();
   }
-
+  
   let transfer = getTransfer(event, wallets)
   transfer.bag = tokenId.toString();
   transfer.save()

--- a/subgraphs/ecosystem/layer1/src/mana-mapping.ts
+++ b/subgraphs/ecosystem/layer1/src/mana-mapping.ts
@@ -1,50 +1,103 @@
-import { Transfer as TransferEvent } from '../generated/GenesisProjectMana/GenesisMana';
-import { getTransfer, getWallets, isZeroAddress } from './utils';
-
-import { Bag, Mana } from '../generated/schema';
-import { GenesisMana } from '../generated/GenesisProjectMana/GenesisMana';
-import { BigInt } from '@graphprotocol/graph-ts';
+import { getTransfer, getWallets, isZeroAddress } from "./utils";
+import { Bag, GAdventurer, Mana, Transfer } from "../generated/schema";
+import { GenesisMana,  Transfer as TransferEvent  } from "../generated/GenesisProjectMana/GenesisMana";
+import { Address, BigInt } from "@graphprotocol/graph-ts";
+import { updateGAdventurerWithLootTokenIds } from "./gadventurer-mapping";
+import { GenesisAdventurer } from "../generated/GenesisProjectAdventurer/GenesisAdventurer";
 
 export function handleTransfer(event: TransferEvent): void {
   let tokenId = event.params.tokenId;
   let wallets = getWallets(event.params.from, event.params.to, event);
 
-  if(!isZeroAddress(wallets.fromWallet.id)) {
-    wallets.fromWallet.manasHeld = wallets.fromWallet.manasHeld.minus(BigInt.fromI32(1))
+  if (!isZeroAddress(wallets.fromWallet.id)) {
+    wallets.fromWallet.manasHeld = wallets.fromWallet.manasHeld.minus(
+      BigInt.fromI32(1)
+    );
   }
-  wallets.fromWallet.save()
+  wallets.fromWallet.save();
 
-  wallets.toWallet.manasHeld = wallets.toWallet.manasHeld.plus(BigInt.fromI32(1))
-  wallets.toWallet.save()
-  
+  wallets.toWallet.manasHeld = wallets.toWallet.manasHeld.plus(
+    BigInt.fromI32(1)
+  );
+  wallets.toWallet.save();
+
   let lootTokenId = "";
   let mana = Mana.load(tokenId.toString());
-    if (mana != null) {
-      mana.currentOwner = wallets.toWallet.id;
-      mana.save();
-    } else {
-      mana = new Mana(tokenId.toString());
-      let contract = GenesisMana.bind(event.address);
-      let manaDetails = contract.detailsByToken(tokenId);
-      lootTokenId =  manaDetails.value0.toString();
-  
-      mana.lootTokenId = lootTokenId
-      mana.itemName = manaDetails.value1;
-      mana.suffixId = manaDetails.value2;
-      mana.inventoryId = manaDetails.value3;
-      mana.currentOwner = wallets.toWallet.id;
-      mana.minted = event.block.timestamp;
-      mana.save();
-    }
-    let bag = Bag.load(lootTokenId);
-    if (bag != null) {
-      if (bag.manasClaimed)
-        bag.manasClaimed = bag.manasClaimed.plus(BigInt.fromI32(1));
-      bag.save();
-    }
-  
-    let transfer = getTransfer(event, wallets)  
-    transfer.mana = tokenId.toString();
-    transfer.save()
-  
+  if (mana != null) {
+    mana.currentOwner = wallets.toWallet.id;
+    mana.save();
+  } else {
+    mana = new Mana(tokenId.toString());
+    let contract = GenesisMana.bind(event.address);
+    let manaDetails = contract.detailsByToken(tokenId);
+    lootTokenId = manaDetails.value0.toString();
+
+    mana.lootTokenId = lootTokenId;
+    mana.itemName = manaDetails.value1;
+    mana.suffixId = manaDetails.value2;
+    mana.inventoryId = manaDetails.value3;
+    mana.currentOwner = wallets.toWallet.id;
+    mana.minted = event.block.timestamp;
+    mana.save();
   }
+  let bag = Bag.load(lootTokenId);
+  if (bag != null) {
+    if (bag.manasClaimed)
+      bag.manasClaimed = bag.manasClaimed.plus(BigInt.fromI32(1));
+    bag.save();
+  }
+
+  let transfer = getTransfer(event, wallets);
+  transfer.mana = tokenId.toString();
+  transfer.save();
+
+  updateGAdventurerIfSummoned(event);
+}
+
+function updateGAdventurerIfSummoned(event: TransferEvent): void {
+  // If GA summoning, last transfer will be the ring at logIndex 16
+  if (event.logIndex.toString() != "16") {
+    return;
+  }
+
+  // GAdventurer is the first transfer in transaction
+  const transaction = event.transaction.hash.toHex();
+  const gaTransfer = Transfer.load(transaction + "-0");
+
+  if (gaTransfer == null || gaTransfer.gAdventurer == null) {
+    return;
+  }
+
+  const tokenId = gaTransfer.gAdventurer as string;
+  const gAdventurer = GAdventurer.load(tokenId);
+  if (gAdventurer == null) {
+    return;
+  }
+  updateGAdventurerWithLootTokenIds(
+    gAdventurer as GAdventurer,
+    [
+      getLootIdByManaTransferId(transaction + "-2"), // Weapon
+      getLootIdByManaTransferId(transaction + "-4"), // Chest
+      getLootIdByManaTransferId(transaction + "-6"), // Head
+      getLootIdByManaTransferId(transaction + "-8"), // Waist
+      getLootIdByManaTransferId(transaction + "-10"), // Foot
+      getLootIdByManaTransferId(transaction + "-12"), // Hand
+      getLootIdByManaTransferId(transaction + "-14"), // Neck
+      getLootIdByManaTransferId(transaction + "-16") // Ring
+    ],
+    GenesisAdventurer.bind(event.transaction.to as Address)
+  );
+  gAdventurer.save();
+}
+
+function getLootIdByManaTransferId(transferId: string): BigInt {
+  const manaTransfer = Transfer.load(transferId);
+  if (manaTransfer == null || manaTransfer.mana == null) {
+    return BigInt.fromI32(0);
+  }
+  const mana = Mana.load(manaTransfer.mana as string);
+  if (mana == null || mana.lootTokenId == null) {
+    return BigInt.fromI32(0);
+  }
+  return BigInt.fromString(mana.lootTokenId);
+}

--- a/subgraphs/ecosystem/layer1/src/mloot-mapping.ts
+++ b/subgraphs/ecosystem/layer1/src/mloot-mapping.ts
@@ -1,44 +1,61 @@
-import { MLoot } from '../generated/schema';
-import { Transfer as TransferEvent } from '../generated/LootMore/LootMore';
-import { LootMore } from '../generated/LootMore/LootMore';
-import { getTransfer, getWallets, isZeroAddress } from './utils';
+import { MLoot } from "../generated/schema";
+import { Transfer as TransferEvent } from "../generated/LootMore/LootMore";
+import { LootMore } from "../generated/LootMore/LootMore";
+import { getTransfer, getWallets, isZeroAddress } from "./utils";
 
-import { BigInt } from '@graphprotocol/graph-ts';
+import { BigInt } from "@graphprotocol/graph-ts";
+import { getBagGreatness, getBagLevel, getBagRating } from "./glr-utils";
 
 export function handleTransfer(event: TransferEvent): void {
   let tokenId = event.params.tokenId;
   let wallets = getWallets(event.params.from, event.params.to, event);
 
-
-  if(!isZeroAddress(wallets.fromWallet.id)) {
-    wallets.fromWallet.mLootsHeld = wallets.fromWallet.mLootsHeld.minus(BigInt.fromI32(1))
+  if (!isZeroAddress(wallets.fromWallet.id)) {
+    wallets.fromWallet.mLootsHeld = wallets.fromWallet.mLootsHeld.minus(
+      BigInt.fromI32(1)
+    );
   }
-  wallets.fromWallet.save()
+  wallets.fromWallet.save();
 
-  wallets.toWallet.mLootsHeld = wallets.toWallet.mLootsHeld.plus(BigInt.fromI32(1))
-  wallets.toWallet.save()
+  wallets.toWallet.mLootsHeld = wallets.toWallet.mLootsHeld.plus(
+    BigInt.fromI32(1)
+  );
+  wallets.toWallet.save();
 
   let mLoot = MLoot.load(tokenId.toString());
-    if (mLoot != null) {
-      mLoot.currentOwner = wallets.toWallet.id;
-      mLoot.save();
-    } else {
-      mLoot = new MLoot(tokenId.toString());
-      let contract = LootMore.bind(event.address);
-      mLoot.chest = contract.getChest(tokenId);
-      mLoot.foot = contract.getFoot(tokenId);
-      mLoot.hand = contract.getHand(tokenId);
-      mLoot.head = contract.getHead(tokenId);
-      mLoot.neck = contract.getNeck(tokenId);
-      mLoot.ring = contract.getRing(tokenId);
-      mLoot.waist = contract.getWaist(tokenId);
-      mLoot.weapon = contract.getWeapon(tokenId);
-      mLoot.currentOwner = wallets.toWallet.id;
-      mLoot.minted = event.block.timestamp;
-      mLoot.save();
-    }
-  
-    let transfer = getTransfer(event, wallets)  
-    transfer.mLoot = tokenId.toString();
-    transfer.save();
+  if (mLoot != null) {
+    mLoot.currentOwner = wallets.toWallet.id;
+    mLoot.save();
+  } else {
+    mLoot = new MLoot(tokenId.toString());
+    let contract = LootMore.bind(event.address);
+    mLoot.chest = contract.getChest(tokenId);
+    mLoot.foot = contract.getFoot(tokenId);
+    mLoot.hand = contract.getHand(tokenId);
+    mLoot.head = contract.getHead(tokenId);
+    mLoot.neck = contract.getNeck(tokenId);
+    mLoot.ring = contract.getRing(tokenId);
+    mLoot.waist = contract.getWaist(tokenId);
+    mLoot.weapon = contract.getWeapon(tokenId);
+    const items = [
+      mLoot.weapon,
+      mLoot.chest,
+      mLoot.head,
+      mLoot.waist,
+      mLoot.foot,
+      mLoot.hand,
+      mLoot.neck,
+      mLoot.ring
+    ];
+    mLoot.bagGreatness = getBagGreatness(tokenId);
+    mLoot.bagLevel = getBagLevel(tokenId, items);
+    mLoot.bagRating = getBagRating(tokenId, items);
+    mLoot.currentOwner = wallets.toWallet.id;
+    mLoot.minted = event.block.timestamp;
+    mLoot.save();
   }
+
+  let transfer = getTransfer(event, wallets);
+  transfer.mLoot = tokenId.toString();
+  transfer.save();
+}

--- a/subgraphs/ecosystem/layer1/subgraph.template.yaml
+++ b/subgraphs/ecosystem/layer1/subgraph.template.yaml
@@ -85,11 +85,14 @@ dataSources:
       entities:
         - Transfer
         - Mana
+        - GAdventurer
         - Wallet
         - Bag
       abis:
         - name: GenesisMana
           file: ./abis/GenesisMana.json
+        - name: GenesisAdventurer
+          file: ./abis/GenesisAdventurer.json
       eventHandlers:
         - event: Transfer(indexed address,indexed address,indexed uint256)
           handler: handleTransfer
@@ -117,6 +120,10 @@ dataSources:
       eventHandlers:
         - event: Transfer(indexed address,indexed address,indexed uint256)
           handler: handleTransfer
+        - event: NameLostMana(uint256,(uint256,uint8)[])
+          handler: handleNameLostMana
+        - event: NameAdventurer(uint256,string)
+          handler: handleNameAdventurer
       file: ./src/gadventurer-mapping.ts
 
   - kind: ethereum/contract

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "@graphprotocol/graph-ts/types/tsconfig.base.json",
+  "include": ["subgraphs/**/src"]
+}


### PR DESCRIPTION
Genesis Adventurer mapping
- Refresh subgraph meta data on v1/v2 subgraph cache
- Handle new events Rename Adventurer/Lost Mana Renaming
- Add Greatness, Level,  and Rating stats

Genesis Mana
- Update Genesis Adventurer on GA Summoning (event not exposed in GA contract)

Loot/MLoot
- Add Greatness, Level, and Rating stats

GLR as defined by:
https://docs.loot.foundation/canonical-principles/loot/loot-classification-and-ratings-system
